### PR TITLE
Exit application with warning if not on Windows

### DIFF
--- a/construct.py
+++ b/construct.py
@@ -1252,6 +1252,12 @@ def loadStyle():
 
 """ Start the program """
 if __name__ == '__main__':
+    if os.name != "nt":
+        app = QApplication(sys.argv)
+        QMessageBox.critical(None, "Not using Windows", 
+            "You are not using a Microsoft Windows operating system.\nConstruct does not support Linux or macOS.")
+        sys.exit(1)
+
     import subprocess
     try:
         subprocess.run(


### PR DESCRIPTION
This commit adds a check for a Windows operating system and ensures that a clear warning is shown for people that are not on Windows. Previously, a warning would appear saying that Git is not installed. This is misleading, as the error is related to the lack of the Windows-dependent `subprocess.CREATE_NO_WINDOW`. Now, when running on Linux (and supposedly macOS), you recieve a clear dialog stating the following:

```
Not using Windows

You are not using a Microsoft Windows operating system.
Construct does not support Linux or macOS.
```

**This commit does NOT add Linux or macOS support.**
This commit was tested on Windows, and the warning does *NOT* appear.